### PR TITLE
Rename go to phantom wallet so that SendMessage from Js always works

### DIFF
--- a/Runtime/Plugins/JavaScriptFunctions/JavaScriptFunctions.jslib
+++ b/Runtime/Plugins/JavaScriptFunctions/JavaScriptFunctions.jslib
@@ -5,7 +5,7 @@ mergeInto(LibraryManager.library, {
             try {
                 const resp = await window.phantom.solana.connect();
                 console.log(resp.publicKey.toString());
-                window.unityInstance.SendMessage('WalletHolderService', 'OnPhantomConnected', resp.publicKey.toString());
+                window.unityInstance.SendMessage('PhantomWallet', 'OnPhantomConnected', resp.publicKey.toString());
             } catch (err) {
                 window.alert(err.toString());
             }
@@ -24,7 +24,7 @@ mergeInto(LibraryManager.library, {
                   },
                });
                 console.log(signedTransaction);
-                window.unityInstance.SendMessage('WalletHolderService', 'OnTransactionSigned', signedTransaction.signature);
+                window.unityInstance.SendMessage('PhantomWallet', 'OnTransactionSigned', signedTransaction.signature);
             } catch (err) {
                 console.error(err.message);
             }
@@ -47,7 +47,7 @@ mergeInto(LibraryManager.library, {
 
                 console.log("Signed and send resulting in signature: " + signature);
 
-                window.unityInstance.SendMessage('WalletHolderService', 'OnTransactionSignedAndSent', signature);
+                window.unityInstance.SendMessage('PhantomWallet', 'OnTransactionSignedAndSent', signature);
             } catch (err) {
                 console.error(err.message);
             }

--- a/Runtime/codebase/PhantomWallet.cs
+++ b/Runtime/codebase/PhantomWallet.cs
@@ -57,6 +57,10 @@ namespace Solana.Unity.SDK
 
             CreatePhantomAppEncryptionKeys();
 #endif
+#if UNITY_WEBGL
+            // For the send message from java script to work the game object needs to have the correct name.
+            gameObject.name = "PhantomWallet";
+#endif
         }
 
         protected override Task<Account> _Login(string password = null)


### PR DESCRIPTION
## Problem

If a user renames the game object that the phantom wallet is on js cant send messages to the object anymore. 

## Solution
I am now forcing the name of the wallet to the correct one. 

